### PR TITLE
Change default pidfile path to the default of capstrano3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ class { 'unicrorn_sysvinit':
     'APP_ROOT'    => '/var/www/myapp',
     'USER'        => 'app',
     'ENVIRONMENT' => 'production',
+    'PID'         => '/var/run/unicorn/unicorn.pid',
     'RUBY_PATH'   => '/opt/ruby2.2.2/bin',
   },
 }

--- a/files/etc/rc.d/init.d/unicorn
+++ b/files/etc/rc.d/init.d/unicorn
@@ -13,7 +13,7 @@ ENVIRONMENT=development
 CONFIG=/etc/sysconfig/unicorn
 [ -f "$CONFIG" ] && . $CONFIG
 
-PID=$APP_ROOT/shared/pids/unicorn.pid
+PID=$APP_ROOT/shared/tmp/pids/unicorn.pid
 
 if [ -n "$RUBY_PATH" ]; then
     CMD="cd $APP_ROOT/current; PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $APP_ROOT/current/config/unicorn.rb"

--- a/files/etc/rc.d/init.d/unicorn
+++ b/files/etc/rc.d/init.d/unicorn
@@ -13,7 +13,9 @@ ENVIRONMENT=development
 CONFIG=/etc/sysconfig/unicorn
 [ -f "$CONFIG" ] && . $CONFIG
 
-PID=$APP_ROOT/shared/tmp/pids/unicorn.pid
+if [ -z "$PID" ]; then
+  PID=$APP_ROOT/shared/tmp/pids/unicorn.pid
+fi
 
 if [ -n "$RUBY_PATH" ]; then
     CMD="cd $APP_ROOT/current; PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $APP_ROOT/current/config/unicorn.rb"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lamanotrama-unicorn_sysvinit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "lamanotrama",
   "summary": "Uncorn sysvinit Module",
   "license": "Apache 2.0",


### PR DESCRIPTION
cap3のデフォルト違うんだよ。
ref https://github.com/tablexi/capistrano3-unicorn/blob/master/lib/capistrano3/tasks/unicorn.rake#L3
ここが相違してしまうと、デプロイ後にinitスクリプトでコントロールできなくなって困るんだよ。

非互換変更なので設定で上書き出来るようにはしたから、各位適当に頼む。
