### PR TITLE
Support cap3 default configpath

### DIFF
--- a/files/etc/rc.d/init.d/unicorn
+++ b/files/etc/rc.d/init.d/unicorn
@@ -17,10 +17,17 @@ if [ -z "$PID" ]; then
   PID=$APP_ROOT/shared/tmp/pids/unicorn.pid
 fi
 
+# cap3 default
+UNICORN_RB="${APP_ROOT}/current/config/unicorn/${ENVIRONMENT}.rb"
+if [ ! -f "$UNICORN_RB" ]; then
+    # cap2 default
+    UNICORN_RB="${APP_ROOT}/current/config/unicorn.rb"
+fi
+
 if [ -n "$RUBY_PATH" ]; then
-    CMD="cd $APP_ROOT/current; PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $APP_ROOT/current/config/unicorn.rb"
+    CMD="cd $APP_ROOT/current; PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
 else
-    CMD="cd $APP_ROOT/current; bundle exec unicorn -E $ENVIRONMENT -D -c $APP_ROOT/current/config/unicorn.rb"
+    CMD="cd $APP_ROOT/current; bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
 fi
 
 # signal utils

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lamanotrama-unicorn_sysvinit",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "lamanotrama",
   "summary": "Uncorn sysvinit Module",
   "license": "Apache 2.0",


### PR DESCRIPTION
The default value of unicorn_config_path changed with capistrano3-unicorn from capistrano-unicorn.
- https://github.com/sosedoff/capistrano-unicorn
- https://github.com/tablexi/capistrano3-unicorn

So, this change makes sure that default of cap3 will be used. And fallback to use default of cap if default of cap3 is not exists.
